### PR TITLE
Upload .py source instead of .pyc bytecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * CI workflow to build and push service images to GitHub Container Registry on master merge. (#97)
 * Pull-first with local build fallback for container images during deployment. (#97)
 
+### Fixed
+
+* Upload .py source instead of .pyc bytecode to decouple host Python version. (#38, #59)
+
 ### Changed
 
 * Completed [ARCHITECTURE.md](./docs/ARCHITECTURE.md) (#93)

--- a/src/remote.py
+++ b/src/remote.py
@@ -39,7 +39,6 @@ remote_node.change_permissions_to_root("/opt/example/content/run.py")
 import functools
 import io
 import logging
-import marshal
 import os
 import pathlib
 import random
@@ -124,12 +123,9 @@ class RemoteConnection:
             mode="r",
             encoding="utf-8"
         ) as memfile:
-            code_object = compile(memfile.read() + command, filename=nonce, mode="exec")
-            pyc_file = io.BytesIO()
-            pyc_file.write(b'o\r\r\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-            marshal.dump(code_object, pyc_file)
-            self.upload_file(content=pyc_file.getvalue(), remote_file_path=f'/opt/{nonce}.pyc')
-        _, stdout, stderr = self.ssh_client.exec_command(f"python3 /opt/{nonce}.pyc")
+            source = memfile.read() + command
+        self.upload_file(content=source, remote_file_path=f'/opt/{nonce}.py')
+        _, stdout, stderr = self.ssh_client.exec_command(f"python3 /opt/{nonce}.py")
         return {
             "output": stdout.read().decode(),
             "error": stderr.read().decode()


### PR DESCRIPTION
Remove `compile()`, `marshal`, and the hardcoded Python 3.10 `.pyc` magic number. Upload plain `.py` source that the container's Python compiles at runtime (<100ms overhead). This decouples host and container Python versions.\n\nCloses #38\nCloses #59