### PR TITLE
Override Gunicorn to use gevent workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Dependabot updates for `github-actions` and `terraform` ecosystems. (#29)
 * CI workflow to build and push service images to GitHub Container Registry on master merge. (#97)
 * Pull-first with local build fallback for container images during deployment. (#97)
+* Gunicorn gevent workers (4 workers, 120s timeout) for async I/O concurrency. (#80)
 
 ### Changed
 

--- a/services/superset/Dockerfile
+++ b/services/superset/Dockerfile
@@ -17,6 +17,7 @@ RUN \
   pip \
     install \
       --no-cache-dir \
+      "gevent==24.2.1" \
       "redis==4.5.4" \
       "mysql-connector-python==9.0.0"
 

--- a/services/superset/entrypoint.sh
+++ b/services/superset/entrypoint.sh
@@ -17,7 +17,14 @@ if superset test_db \
   superset init
   
   /app/set_database_uri.exp
-  /usr/bin/run-server.sh &
+  gunicorn \
+    --bind 0.0.0.0:8088 \
+    --workers 4 \
+    --worker-class gevent \
+    --timeout 120 \
+    --limit-request-line 8190 \
+    --forwarded-allow-ips "*" \
+    "superset.app:create_app()" &
 
   celery \
     --app superset.tasks.celery_app:app worker \


### PR DESCRIPTION
Replace default `run-server.sh` with explicit Gunicorn config: 4 workers, gevent worker class, 120s timeout. Install gevent in the Dockerfile. Gevent async I/O prevents sync worker blocking during concurrent MySQL/Redis I/O.

Closes #80