### PR TITLE
Add --debug flag and structured logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Strengthen MySQL superset password: secrets module, expanded charset, 24 chars. (#89)
 * SQL Lab query row limits, timeout caps, and validation timeout. (#81)
 * Superset metastore and explore form data caching via Redis. (#79)
-
-### Added
-
 * `--debug` flag and structured logging with `configure_logging()`. (#67)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * SQL Lab query row limits, timeout caps, and validation timeout. (#81)
 * Superset metastore and explore form data caching via Redis. (#79)
 
+### Added
+
+* `--debug` flag and structured logging with `configure_logging()`. (#67)
+
 ### Changed
 
 * Completed [ARCHITECTURE.md](./docs/ARCHITECTURE.md) (#93)

--- a/src/initialize.py
+++ b/src/initialize.py
@@ -59,12 +59,27 @@ import base64
 import functools
 import ipaddress
 import itertools
+import logging
+import os
 import re
 import socket
 
 import crypto
 import decorators
 import remote
+
+
+def configure_logging() -> None:
+    level = logging.DEBUG if os.environ.get('SUPERSET_CLUSTER_DEBUG') else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s'
+    )
+    logging.getLogger('paramiko').setLevel(logging.WARNING)
+    logging.getLogger('urllib3').setLevel(logging.WARNING)
+
+
+logger = logging.getLogger(__name__)
 
 
 @decorators.Overlay.run_all_methods  # type: ignore[arg-type]
@@ -299,6 +314,7 @@ class Controller(ArgumentParser, metaclass=decorators.Overlay):
 
 if __name__ == "__main__":
     if len(sys.argv) != 6:
-        print("Invalid form of arguments provided")
+        logger.error("Invalid form of arguments provided")
         sys.exit(1)
+    configure_logging()
     Controller().start_cluster()

--- a/src/remote.py
+++ b/src/remote.py
@@ -94,7 +94,12 @@ class RemoteConnection:
             result = func(*args, **kwargs)
             if result["output"]:
                 logger.info(
-                    "[Node: %s] Command: %s - Output:\n%s",
+                    "[Node: %s] Command: %s completed",
+                    getattr(self, 'node', 'UnknownNode'),
+                    command
+                )
+                logger.debug(
+                    "[Node: %s] Command: %s - stdout:\n%s",
                     getattr(self, 'node', 'UnknownNode'),
                     command,
                     result["output"]
@@ -102,6 +107,12 @@ class RemoteConnection:
             if result["error"]:
                 logger.error(
                     "[Node: %s] Command: %s - Error:\n%s",
+                    getattr(self, "node", "UnknownNode"),
+                    command,
+                    result["error"]
+                )
+                logger.debug(
+                    "[Node: %s] Command: %s - stderr:\n%s",
                     getattr(self, "node", "UnknownNode"),
                     command,
                     result["error"]

--- a/superset-cluster
+++ b/superset-cluster
@@ -20,6 +20,8 @@ display_help() {
     echo "  --virtual-network-mask <mask>           Network mask for the virtual network gateway."
     echo "                                          Example: --virtual-network-mask 24"
     echo
+    echo "  --debug                               Enable debug-level logging."
+    echo
     echo "  -h, --help                              Show this help message and exit."
     echo
     echo "Example:"
@@ -58,6 +60,9 @@ parse_arguments() {
             -h|--help)
                 display_help
                 exit 0
+                ;;
+            --debug)
+                export SUPERSET_CLUSTER_DEBUG=1
                 ;;
             *)
                 echo "Unknown option: $1"


### PR DESCRIPTION
Add `--debug` flag to the shell script and `configure_logging()` in initialize.py. Replace `print()` with `logger` calls. Enhance `@log_remote_command_execution` to emit raw stdout/stderr at DEBUG level.

Closes #67
Closes #53