### PR TITLE
Redact plaintext MySQL password from superset entrypoint logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Redacted MySQL password from `superset` entrypoint's `test_db` output and disabled `-x` tracing around it,
+  preventing plaintext password exposure in `docker logs`/`docker service logs`.
 * Upload `.py` source instead of `.pyc` bytecode to decouple host Python version. (#38, #41)
 * Fixed `run_mysql_server()` not instantiating `MySQLServer` class. (#94)
 * Disabled MD060 markdownlint rule to fix table column style false positives in documentation. (#94)

--- a/services/superset/entrypoint.sh
+++ b/services/superset/entrypoint.sh
@@ -5,18 +5,8 @@ set -euo pipefail
 DB_PASSWORD=$(< /run/secrets/mysql_superset_password)
 DB_URI="mysql+mysqlconnector://superset:${DB_PASSWORD}@${VIRTUAL_IP_ADDRESS}:6446/superset"
 
-# -x stays off here: tracing this line, or superset test_db's own "SQLAlchemy
-# URI" printout, would put the plaintext DB password into docker logs/docker
-# service logs. Redact stdout+stderr as a backstop in case anything
-# downstream still echoes the URI.
 if superset test_db "$DB_URI" --connect-args {} 2>&1 \
-    | DB_PASSWORD="$DB_PASSWORD" python3 -c '
-import os, sys
-pw = os.environ["DB_PASSWORD"]
-for line in sys.stdin:
-    sys.stdout.write(line.replace(pw, "<redacted>"))
-    sys.stdout.flush()
-'; then
+    | DB_PASSWORD="$DB_PASSWORD" python3 /app/redact_secret.py; then
   set -x
 
   superset fab create-admin \

--- a/services/superset/entrypoint.sh
+++ b/services/superset/entrypoint.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
-if superset test_db \
-    "mysql+mysqlconnector://superset:$(< /run/secrets/mysql_superset_password)@${VIRTUAL_IP_ADDRESS}:6446/superset" \
-    --connect-args {}; then
-  
+DB_PASSWORD=$(< /run/secrets/mysql_superset_password)
+DB_URI="mysql+mysqlconnector://superset:${DB_PASSWORD}@${VIRTUAL_IP_ADDRESS}:6446/superset"
+
+# -x stays off here: tracing this line, or superset test_db's own "SQLAlchemy
+# URI" printout, would put the plaintext DB password into docker logs/docker
+# service logs. Redact stdout+stderr as a backstop in case anything
+# downstream still echoes the URI.
+if superset test_db "$DB_URI" --connect-args {} 2>&1 \
+    | DB_PASSWORD="$DB_PASSWORD" python3 -c '
+import os, sys
+pw = os.environ["DB_PASSWORD"]
+for line in sys.stdin:
+    sys.stdout.write(line.replace(pw, "<redacted>"))
+    sys.stdout.flush()
+'; then
+  set -x
+
   superset fab create-admin \
   --username "superset" \
   --firstname "superset" \

--- a/services/superset/redact_secret.py
+++ b/services/superset/redact_secret.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+pw = os.environ["DB_PASSWORD"]
+for line in sys.stdin:
+    sys.stdout.write(line.replace(pw, "<redacted>"))
+    sys.stdout.flush()


### PR DESCRIPTION
## Summary
- `entrypoint.sh` ran under `set -euxo pipefail`, so the `-x` trace printed the fully-substituted `superset test_db mysql+mysqlconnector://superset:<password>@...` command to stderr on every start.
- Separately, `superset test_db` itself prints the full SQLAlchemy connection URI (password included) to stdout as part of its "Collecting additional connection information..." output.
- Both ended up in `docker logs superset` / `docker service logs superset` (no node access needed) and persisted indefinitely in the host's default json-file log driver (no rotation configured).

## Fix
- Build the DB URI in a variable with `-x` off, so bash's own trace never echoes the password. `-x` resumes right after the connectivity check for the rest of the script (create-admin, db upgrade, celery, etc. — unaffected).
- Pipe `test_db`'s combined stdout/stderr through a small inline `python3` filter that does a literal string-replace of the password with `<redacted>`, as a backstop for Superset's own URI printout, which can't be silenced via bash flags since it's the CLI's own behavior.
- `pipefail` (already set) still correctly propagates `test_db`'s real exit code through the pipe, so the `if`/`else` connectivity check is unaffected.
- Added a `CHANGELOG.md` entry under `### Fixed`.

## Test plan
- [x] `bash -n services/superset/entrypoint.sh` — syntax OK
- [x] Simulated both leak sources (bash `-x` trace line, and Superset's "SQLAlchemy URI: ..." printout) through the redaction filter locally — both resolve to `<redacted>`
- [ ] Re-run the `docker service logs superset | grep -c '<password>'` check from the original test writeup against a live cluster (no docker/cluster access in the environment this was developed in)