### PR TITLE
Deduplicate HTTP security headers between nginx and Flask-Talisman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Deduplicated HTTP security headers between nginx and Flask-Talisman: nginx now hides Talisman's upstream
+  copies via `proxy_hide_header` and is the sole source of `Strict-Transport-Security`, `X-Frame-Options`,
+  `X-XSS-Protection`, `X-Content-Type-Options`, and `Referrer-Policy`, applied with `always` so they persist
+  on error responses too. Corrected `Referrer-Policy` to `strict-origin-when-cross-origin`.
 * Upload `.py` source instead of `.pyc` bytecode to decouple host Python version. (#38, #41)
 * Fixed `run_mysql_server()` not instantiating `MySQLServer` class. (#94)
 * Disabled MD060 markdownlint rule to fix table column style false positives in documentation. (#94)

--- a/services/superset/nginx.conf
+++ b/services/superset/nginx.conf
@@ -21,11 +21,17 @@ http {
         ssl_prefer_server_ciphers on;
         ssl_session_cache shared:SSL:10m;
 
+        proxy_hide_header Strict-Transport-Security;
+        proxy_hide_header X-Content-Type-Options;
+        proxy_hide_header X-Frame-Options;
+        proxy_hide_header X-XSS-Protection;
+        proxy_hide_header Referrer-Policy;
+
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-        add_header X-Content-Type-Options nosniff;
-        add_header X-Frame-Options DENY;
-        add_header X-XSS-Protection "1; mode=block";
-        add_header Referrer-Policy "no-referrer-when-downgrade";
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options DENY always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
         server_tokens off;
         tcp_nopush on;

--- a/tests/testsuite/roles/testing/files/functional_superset.py
+++ b/tests/testsuite/roles/testing/files/functional_superset.py
@@ -294,6 +294,42 @@ class Superset(container.ContainerConnection, metaclass=decorators.Overlay):
             swarm_info["ControlAvailable"] is True, \
             "The testing localhost is supposed to be a Swarm manager, but it is not"
 
+    @decorators.Overlay.run_selected_methods_once
+    def status_headers(self) -> None:
+        expected_headers = {
+            "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+            "x-content-type-options": "nosniff",
+            "x-frame-options": "DENY",
+            "x-xss-protection": "1; mode=block",
+            "referrer-policy": "strict-origin-when-cross-origin",
+        }
+        for path in ("/", "/this-path-does-not-exist-xyz"):
+            command = f"""
+                curl \
+                    --cacert /app/server_certificate.pem \
+                    --silent \
+                    --head \
+                    https://{self.virtual_ip_address}{path}
+            """
+            response = self.run_command_on_the_container(command).decode("utf-8")
+            response_lines = [line.strip() for line in response.splitlines() if ":" in line]
+            for header_name, expected_value in expected_headers.items():
+                matches = [
+                    line.split(":", 1)[1].strip()
+                    for line in response_lines
+                    if line.split(":", 1)[0].strip().lower() == header_name
+                ]
+                assert \
+                    len(matches) == 1, \
+                    f"""Expected exactly one {header_name} header on {path}, found {len(matches)}: {matches}
+                        \nCommand: {command!r}\nReturned: {response!r}
+                    """
+                assert \
+                    matches[0] == expected_value, \
+                    f"""Expected {header_name} to be {expected_value!r} on {path}, got {matches[0]!r}
+                        \nCommand: {command!r}\nReturned: {response!r}
+                    """
+
     def run_query(self) -> float:
         payload = '{"database_id": 1, "runAsync": true, "sql": "SELECT * FROM superset.logs;"}'
         command = f"""


### PR DESCRIPTION
## Summary
- nginx (`services/superset/nginx.conf`) and Superset's own Flask-Talisman middleware both independently add `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Referrer-Policy` to every response. `add_header` doesn't replace upstream headers, it appends — so responses carried duplicates with different values, and per spec/browser handling this wasn't "defense in depth," it was silent misconfiguration:
  - **HSTS**: RFC 6797 mandates only the *first* STS header is processed. Superset's weaker copy (no `preload`) came first, so nginx's `preload` copy was spec-mandated to be ignored entirely.
  - **X-Frame-Options**: `SAMEORIGIN` vs `DENY` risked comma-joining into an invalid value on some browsers (documented: Safari 6.0.5), which can drop clickjacking protection entirely.
  - **Referrer-Policy**: UAs take the *last* valid policy across combined headers — nginx's weaker legacy default (`no-referrer-when-downgrade`) silently overrode Superset's stricter `strict-origin-when-cross-origin`.
  - Only nginx's HSTS line carried `always`, so its other four headers vanished on non-2xx/3xx responses (404, 500) — the response was only still hardened because Talisman's headers are unconditional.

## Fix
- Added `proxy_hide_header` for all five headers so Talisman's upstream copies never reach the client, and made nginx's own `add_header` lines (all now with `always`) the sole source of truth — headers now survive on error pages too.
- Corrected `Referrer-Policy` to `strict-origin-when-cross-origin`. Kept `X-Frame-Options: DENY` (nginx's existing, stricter value — no dashboard-embedding feature exists anywhere in this repo, so nothing depends on same-origin framing).
- Left Talisman's `TALISMAN_CONFIG`/CSP entirely untouched. Reconfiguring Talisman instead would have required replicating Superset's internal default CSP dict verbatim to safely override the monolithic `TALISMAN_CONFIG`, without ground-truth on the exact defaults shipped in `apache/superset:4.0.2` — not worth the risk of silently weakening CSP when the nginx-side fix is fully sufficient.
- Added `CHANGELOG.md` entry under `### Fixed`.

## Test plan
- [x] Added `status_headers()` to `functional_superset.py`, following the existing `status_database`/`status_swarm` pattern (auto-runs via the `Overlay` metaclass on instantiation, no `functional.yml` changes needed). Curls both `/` and a nonexistent path, asserts each of the 5 headers appears **exactly once** with the exact expected value on both — directly encodes this PR's acceptance criteria as a regression test.
- [x] `python3 -m py_compile`, `flake8`, `pylint` all pass on the modified test file (two pylint import-error warnings are pre-existing and confirmed unrelated by diffing against `master`).
- [x] Manually simulated the header-parsing logic against realistic `curl -I` output.
- [ ] No live docker/cluster access in the environment this was developed in — worth running the new functional test (and `nginx -t`) against an actual deployment before merge.