### PR TITLE
Always pull latest image and serialize publishes per image tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ jobs:
     permissions:
       contents: "read"
       packages: "write"
+    concurrency:
+      group: "publish-${{ matrix.image }}"
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:

--- a/src/container.py
+++ b/src/container.py
@@ -103,11 +103,11 @@ class ContainerConnection:
     @staticmethod
     def pull_or_build_image(client: docker.client.DockerClient, image: str, build_context: str) -> None:
         try:
-            client.images.get(image)
-        except docker.errors.ImageNotFound:
+            client.images.pull(image)
+        except (docker.errors.DockerException, requests.exceptions.RequestException):
             try:
-                client.images.pull(image)
-            except (docker.errors.DockerException, requests.exceptions.RequestException):
+                client.images.get(image)
+            except docker.errors.ImageNotFound:
                 client.images.build(path=build_context, tag=image)
 
     def run_command_on_the_container(


### PR DESCRIPTION
## Summary
- `pull_or_build_image()` (`src/container.py`) checked the local Docker cache first and only pulled/built when the image was entirely absent, so any node with a cached tag kept running stale code indefinitely even after CI published a newer image. It now always attempts a registry pull first.
- `publish.yml` had no `concurrency` guard, letting near-simultaneous pushes to `master` race to push the same `:latest` tag - whichever job finished last won, regardless of commit order. This is the exact bug that caused #169's header-dedup fix to be silently overwritten by #168's slower-finishing publish job (see `superset-cluster-tests/headers.md`'s retest section for the full writeup). A per-image `concurrency` group now serializes those pushes.

## Test plan
- [x] Confirmed both bugs independently via live testing on a deployed cluster (documented in `superset-cluster-tests/headers.md`)
- [ ] Merge and confirm the resulting `Publish` run produces a `:latest` digest that differs from the known-stale `sha256:d3af7a20...`
- [ ] Redeploy and confirm HTTP security headers are no longer duplicated on both 2xx and non-2xx responses